### PR TITLE
Allow Script Versioning (and file loading changes)

### DIFF
--- a/src/main/java/com/denizenscript/denizen2core/events/ScriptEvent.java
+++ b/src/main/java/com/denizenscript/denizen2core/events/ScriptEvent.java
@@ -122,6 +122,15 @@ public abstract class ScriptEvent implements Cloneable {
                 data.eventPath = res.toString().trim();
                 if (couldMatch(data)) {
                     try {
+
+                        // If the script has been overridden, its events will not trigger.
+                        if (script.override) {
+                            Debug.info(ColorSet.warning + "Script '" + ColorSet.emphasis + script.title  +
+                                    " v" + script.version + ColorSet.warning +"' has a world script that has been overridden by version " +
+                                    Denizen2Core.currentScripts.get(script.title).version + ". As a result, this world script will not trigger.");
+                            continue;
+                        }
+
                         usages.add(data);
                         if (generalDebug) {
                             Debug.good("Script event match: " + ColorSet.emphasis + getName()

--- a/src/main/java/com/denizenscript/denizen2core/scripts/CommandScript.java
+++ b/src/main/java/com/denizenscript/denizen2core/scripts/CommandScript.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen2core.scripts;
 
+import com.denizenscript.denizen2core.Denizen2Core;
 import com.denizenscript.denizen2core.commands.CommandScriptSection;
 import com.denizenscript.denizen2core.utilities.debugging.ColorSet;
 import com.denizenscript.denizen2core.utilities.debugging.Debug;
@@ -21,11 +22,17 @@ public abstract class CommandScript {
 
     public long ticksRan = 0;
 
+    public final String version;
+
+    // When override is true, a newer version of this script has been loaded.
+    public boolean override = false;
+
     public final HashMap<String, CommandScriptSection> sections = new HashMap<>();
 
     public CommandScript(String name, YAMLConfiguration section) {
         title = name;
         contents = section;
+        version = section.getString("version", "0");
     }
 
     // <--[explanation]
@@ -92,6 +99,12 @@ public abstract class CommandScript {
                 }
             }
         }
+        return true;
+    }
+
+    // Can be called to 'de-initialize' a script TODO: Possibly call this 'deinitialize', or 'deinit'?
+    public boolean exit() {
+        // TODO: Remove from currentScripts?
         return true;
     }
 

--- a/src/main/java/com/denizenscript/denizen2core/scripts/ScriptHelper.java
+++ b/src/main/java/com/denizenscript/denizen2core/scripts/ScriptHelper.java
@@ -33,4 +33,36 @@ public class ScriptHelper {
         result.append("\n");
         return result.toString();
     }
+
+    /**
+     * Compares two version strings.
+     *
+     * Use this instead of String.compareTo() for a non-lexicographical
+     * comparison that works for version strings. e.g. "1.10".compareTo("1.6").
+     *
+     * @note It does not work if "1.10" is supposed to be equal to "1.10.0".
+     *
+     * @param str1 a string of ordinal numbers separated by decimal points.
+     * @param str2 a string of ordinal numbers separated by decimal points.
+     * @return The result is a negative integer if str1 is _numerically_ less than str2.
+     *         The result is a positive integer if str1 is _numerically_ greater than str2.
+     *         The result is zero if the strings are _numerically_ equal.
+     */
+    public static int versionCompare(String str1, String str2) {
+        String[] vals1 = str1.split("\\.");
+        String[] vals2 = str2.split("\\.");
+        int i = 0;
+        // set index to first non-equal ordinal or length of shortest version string
+        while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
+            i++;
+        }
+        // compare first non-equal ordinal number
+        if (i < vals1.length && i < vals2.length) {
+            int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
+            return Integer.signum(diff);
+        }
+        // the strings are equal or one string is a substring of the other
+        // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+        return Integer.signum(vals1.length - vals2.length);
+    }
 }

--- a/src/main/java/com/denizenscript/denizen2core/scripts/commontypes/WorldScript.java
+++ b/src/main/java/com/denizenscript/denizen2core/scripts/commontypes/WorldScript.java
@@ -42,4 +42,11 @@ public class WorldScript extends CommandScript {
         }
         return false;
     }
+
+    @Override
+    public boolean exit() {
+        ScriptEvent.currentWorldScripts.remove(this);
+        return true;
+    }
+
 }

--- a/src/main/java/com/denizenscript/denizen2core/tags/objects/ScriptTag.java
+++ b/src/main/java/com/denizenscript/denizen2core/tags/objects/ScriptTag.java
@@ -71,6 +71,18 @@ public class ScriptTag extends AbstractTagObject {
             return new BooleanTag(((ScriptTag) obj).internal.contents.isList(dat.getNextModifier().toString()));
         });
         // <--[tag]
+        // @Since 0.4.0
+        // @Name ScriptTag.version
+        // @Updated 2018/04/90
+        // @Group Identification
+        // @ReturnType TextTag
+        // @Returns the version of the script, as set by its version key. If no version is specified, returns '0'
+        // -->
+        handlers.put("version", (dat, obj) -> {
+            String val = ((ScriptTag) obj).internal.version;
+            return new TextTag(val);
+        });
+        // <--[tag]
         // @Since 0.3.0
         // @Name ScriptTag.yaml_key[<TextTag>]
         // @Updated 2017/02/19


### PR DESCRIPTION
This commit changes the script loader to allow versioning of scripts. To version a script, just add a YAML key in line with 'type' called 'version'. If no version is specified, '0' is assumed.

```
my task script:
  type: task
  version: 1.0
  script:
  - echo 'Version 1.0, reporting.'
```

```
my task script:
  type: task
  version: 2.0
  script:
  - echo 'Version 2.0, reporting.'
```

Assume both scripts are called to load (in separate files, as duplicate yaml keys will be ignored straight up). Both scripts will be loaded, but version 1.0 will be renamed 'my task script_1.0', and the highest/newest version will be loaded as 'my task script'.

For example, calling 
```
- run 'my task script'
```
will result in an echo of 'Version 2.0, reporting'.

Need to run a specific version of a task script? Just specify a --version argument in the run command.
```
- run 'my task script' --version 1.0
``` 

This concept should allow for utility/task scripts to be packaged in scripts without fear of breaking previous implementations, given precautions are taken. The versioning will ensure the newest script is loaded and called by default, but allows for backwards or explicit compatibility if needed. It also handles straight up script duplication.

This pull also proposes a (hopefully) compromise to file names, allowing the script loader to be agnostic of file extensions, except for .disabled which will keep the script from loading. File types that are not scripts will error out normally as they will not meet the requirements to be loaded in the first place. This means we can have .yml, .yaml, or even .dscript files without explicitly requiring those extensions. My sublime text syntax highlighting can now detect and highlight a Denizen Script file by detecting a .dscript extension.

Looking forward to discussion/suggestions/etc.
